### PR TITLE
Clarify which key is needed for decrypting a SAML assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 It uses the SAML2 php library along with its dependencies.
 
 * `> docker compose up -d`
-* copy private key named "saml.pem" into ./application/
+* copy the SP's private key to ./application/saml.pem
 * Browse to your local host
 * Copy and paste saml assertion into the textarea and click on Submit


### PR DESCRIPTION
### Fixed
- Clarify which key is needed for decrypting a SAML assertion