### PR TITLE
Fix windows EOL on git pull

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.conf            text   eol=lf
+*.sh              text   eol=lf   diff=bash

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.conf            text   eol=lf
-*.sh              text   eol=lf   diff=bash
+*.sh              text   eol=lf


### PR DESCRIPTION
When i pull the repository on Windows, the default behavior is to get text files with Windows EOL `\r\n`. And that breaks the scripts when they are copied into the docker image. It causes errors like `bash\r not found` in the running container.

It can be fixed with `.gitattributes` telling git to always checkout `*.sh` files with the `\n` EOL.